### PR TITLE
refactor: pull credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,11 @@ So you've cloned the repo. Cool! Here's what you need to do first.
 
 ## Setting up API Tokens
 
-You'll need to [apply with RTM](https://www.rememberthemilk.com/services/api/keys.rtm) for an API token. Once you have one, you can create a file under `api/secrets.go`, with contents like so.
+You'll need to [apply with RTM](https://www.rememberthemilk.com/services/api/keys.rtm) for an API token. You'll need to configure credentials in your environment like so:
 
 ```
-package api
-
-const (
-	// APIKey is the API key provided to us by remember the milk
-	APIKey = "YOUR API KEY"
-	// SharedSecret is the secret used to sign API requests
-	SharedSecret = "YOUR SHARED SECRET"
-)
-```
+GOMILK_API_KEY=yourapikeyhere
+GOMILK_SHARED_SECRET=yoursharedsecret
 
 The terms of the RTM API key require me to protect my app's credentials. Sorry!
 

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	APIKey       = os.Getenv("GOMILK_API_KEY")
+	SharedSecret = os.Getenv("GOMILK_SHARED_SECRET")
+)
+
+func ValidateCredentials() {
+	for _, varName := range []string{"GOMILK_API_KEY", "GOMILK_SHARED_SECRET"} {
+		if _, found := os.LookupEnv(varName); !found {
+			panic(errors.New("miaaing env var: " + varName))
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dishbreak/gomilk/api"
 	"github.com/dishbreak/gomilk/cli/add"
 	"github.com/dishbreak/gomilk/cli/complete"
 	"github.com/dishbreak/gomilk/cli/due"
@@ -14,6 +15,8 @@ import (
 )
 
 func main() {
+	api.ValidateCredentials()
+
 	app := cli.NewApp()
 	app.Name = "gomilk"
 	app.Usage = "Remember the Milk command-line client."


### PR DESCRIPTION
This PR moves us away from hardcoded credentials in to credentials loaded dynamically at runtime.

In order to protect the rest of the application from cryptic API errors, this PR also adds a `ValidateCredentials` function to the api which will panic when there are no credentials set.

This should set us up for builds via AWS CodeBuild